### PR TITLE
Add info about firmware version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Functionality provided via the ARIA website:
 - Transfer Kit to specific memory slot
 - Transfer Pattern to specific memory slot
 - Delete a specific user sample from memory
+- Check firmware version
 
 
 


### PR DESCRIPTION
It looks like the AIRA site can also determine the firmware version so I added a note about this for the README.

<img width="965" alt="Screen Shot 2020-05-03 at 19 23 08" src="https://user-images.githubusercontent.com/4022790/80928624-bb383580-8d73-11ea-904f-9f23a7140c84.png">
